### PR TITLE
Automatic event unsubscribing in Vue 2 when used in options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ function plugin(Vue) {
         eventMap[key] = this.$options.events[key].bind(this)
       }
       // Listen for the `hook:beforeMount` Vue 2.0 life-cycle event.
-      this.$on('hook:beforeMount', () => {
+      this.$once('hook:beforeMount', () => {
         // Loop through each event.
         for (var key in eventMap) {
           // Register a listener for the event.
@@ -107,7 +107,7 @@ function plugin(Vue) {
         }
       })
       // Listen for the `hook:beforeDestroy` Vue 2.0 life-cycle event.
-      this.$on('hook:beforeDestroy', () => {
+      this.$once('hook:beforeDestroy', () => {
         // Loop through each event.
         for (var key in eventMap) {
           // Register a listener for the event.


### PR DESCRIPTION
This pull request will enable automatic event *un*subscription when used in this manner:

`Test.vue`
```js
<template></template>
<script>
export default {
  name: 'test',
  events: {
    disconnected() {
      // Do something here...
    }
  }
}
</script>
```

Currently the events aren't unsubscribed -- Which is especially a problem when using HMR.